### PR TITLE
fix: chinese bold and use typst 0.13 feature

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -323,7 +323,7 @@
 
   show strong: it => text(font: 字体.黑体, weight: "semibold", it.body)
   show emph: it => text(font: 字体.楷体, style: "italic", it.body)
-  set par(first-line-indent: 2em, leading: 1.20em)
+  set par(first-line-indent: (amount: 2em, all: true), leading: 1.20em)
   show raw: set text(font: 字体.代码)
 
   show figure: it => [
@@ -366,7 +366,7 @@
 
   show heading: it => {
     // Cancel indentation for headings
-    set par(first-line-indent: 0em)
+    set par(first-line-indent: (amount: 0em, all: true))
 
     let sizedheading(it, size) = [
       #set text(size : size, font : 字体.黑体)

--- a/template/abstract.typ
+++ b/template/abstract.typ
@@ -1,8 +1,9 @@
+#import "@preview/cuti:0.3.0": *
 #import "font.typ": *
 #let abstract_title(title) = {
   align(center + top)[
     #set text(font: 字体.黑体, size: 字号.三号)
-    #strong[#title]
+    #fakebold[#title]
   ]
 }
 
@@ -11,7 +12,7 @@
     #set align(top + start)
     #abstract_title(abstract_name)
     #set text(font: 字体.宋体, size: 字号.小四)
-    #set par(justify: true, first-line-indent: 2em, leading: 2em, spacing: 2em)
+    #set par(justify: true, first-line-indent: (amount: 2em, all: true), leading: 2em, spacing: 2em)
     #abstract
 
     #v(1em)

--- a/template/claim.typ
+++ b/template/claim.typ
@@ -26,7 +26,7 @@
   block()[
     #SubClaimTitle([*原创性声明*])
 
-    #set par(first-line-indent: 2em, justify: true, leading: 1em)
+    #set par(first-line-indent: (amount: 2em, all: true), justify: true, leading: 1em)
     #set text(font : 字体.宋体, size : 字号.小四)
     #set align(start + top)
     本人郑重声明：所呈交的学位论文，是本人在导师的指导下，独立进行研究工作所取得的成果。除文中已经注明引用的内容外，本论文不含任何其他个人或集体已经发表或撰写过的作品或成果。对本文的研究做出重要贡献的个人和集体，均已在文中以明确方式标明。本声明的法律结果由本人承担。
@@ -41,7 +41,7 @@
 #let TermofUseandAuthorization(year, month, day, teacher_sign : none, my_sign : none) = {
   block()[
     #SubClaimTitle([*学位论文使用授权说明*])
-    #set par(first-line-indent: 2em, justify: true, leading: 1em)
+    #set par(first-line-indent: (amount: 2em, all: true), justify: true, leading: 1em)
     #set text(font : 字体.宋体, size : 字号.小四)
     #set align(start + top)
 

--- a/template/content.typ
+++ b/template/content.typ
@@ -1,10 +1,11 @@
+#import "@preview/cuti:0.3.0": *
 #import "font.typ": *
 #import "numbering.typ" : *
 #let lengthceil(len, unit: 字号.小四) = calc.ceil(len / unit) * unit
 #let chineseoutline(depth: none, indent: true) = {
   align(top + center)[
     #set text(font : 字体.黑体, size : 字号.小二)
-    #strong[目#h(1em)录]
+    #fakebold[目#h(1em)录]
     #v(1em)
   ]  
 
@@ -12,7 +13,7 @@
   set align(top)
   context {
     let elements = query(heading.where(outlined: true))
-    set par(leading: 1em, first-line-indent: 0em)
+    set par(leading: 1em, first-line-indent: (amount: 2em, all: true))
     for el in elements {
 
       let maybe_number = if el.numbering != none {

--- a/thesis.typ
+++ b/thesis.typ
@@ -10,7 +10,7 @@
 // 封面修改后位本科生版本
 // TitlePage参数全部必填
 #TitlePage(
-  chinese_title: [#strong[Typst：世界前沿的排版系统]],
+  chinese_title: [#fakebold[Typst：世界前沿的排版系统]],
   english_title: [#strong[Typst: State-of-art Formatting System]],
   name : "小北",
   studentid : "21000xxxxx",


### PR DESCRIPTION
此pr用于解决https://github.com/EmptyBlueBox/PKU_Undergraduate_Thesis_Template/issues/5 此issue

使用了cuti包来解决中文字体粗体问题，并将`set par(first-line-indent: 2em)` 改为`set par(first-line-indent: (amount: 2em, all: true))`，这是typst0.13版本的新feature.